### PR TITLE
Add custom marshal implementation for protobuf value type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/elastic/elastic-agent-libs v0.2.7
 	github.com/magefile/mage v1.13.0
 	github.com/stretchr/testify v1.7.0
+	go.elastic.co/fastjson v1.1.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
@@ -17,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.elastic.co/ecszap v1.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,7 @@ go.elastic.co/apm/v2 v2.0.0/go.mod h1:KGQn56LtRmkQjt2qw4+c1Jz8gv9rCBUU/m21uxrqcp
 go.elastic.co/ecszap v1.0.0/go.mod h1:HTUi+QRmr3EuZMqxPX+5fyOdMNfUu5iPebgfhgsTJYQ=
 go.elastic.co/ecszap v1.0.1 h1:mBxqEJAEXBlpi5+scXdzL7LTFGogbuxipJC0KTZicyA=
 go.elastic.co/ecszap v1.0.1/go.mod h1:SVjazT+QgNeHSGOCUHvRgN+ZRj5FkB7IXQQsncdF57A=
+go.elastic.co/fastjson v1.1.0 h1:3MrGBWWVIxe/xvsbpghtkFoPciPhOCmjsR/HfwEeQR4=
 go.elastic.co/fastjson v1.1.0/go.mod h1:boNGISWMjQsUPy/t6yqt2/1Wx4YNPSe+mZjlyw9vKKI=
 go.elastic.co/go-licence-detector v0.5.0/go.mod h1:fSJQU8au4SAgDK+UQFbgUPsXKYNBDv4E/dwWevrMpXU=
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/pkg/helpers/struct_test.go
+++ b/pkg/helpers/struct_test.go
@@ -2,13 +2,108 @@ package helpers
 
 import (
 	"encoding/base64"
-	"testing"
+	"encoding/json"
 	"time"
+
+	"testing"
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-shipper-client/pkg/proto/messages"
 	"github.com/stretchr/testify/require"
 )
+
+var marshalResult = []byte{}
+
+func BenchmarkCustomMarshal(b *testing.B) {
+	testMapInput := mapstr.M{
+		"StrTest":  "teststr",
+		"Uint1":    32,
+		"Uint2":    556,
+		"Float1":   23.0,
+		"Float2":   25.343564,
+		"TestNil":  nil,
+		"TestBool": false,
+		"TestList": []interface{}{"strval", 5, false},
+		"TestMap":  map[string]string{"testkey": "val"},
+		"TestMapStr": mapstr.M{"key1": 5, "key2": "strval", "keymap": mapstr.M{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
+		}},
+	}
+
+	testMessage, err := NewValue(testMapInput)
+	if err != nil {
+		b.Logf("error creating value from struct: %s", err)
+		b.FailNow()
+	}
+	b.ResetTimer()
+	b.Run("marshal custom protobuf message.Value type", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			jsonEventData, err := json.Marshal(testMessage)
+			if err != nil {
+				b.Logf("error marshaling data: %s", err)
+				b.FailNow()
+			}
+			marshalResult = jsonEventData
+		}
+	})
+	b.Run("standard struct using stdlib", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			jsonEventData, err := json.Marshal(testMapInput)
+			if err != nil {
+				b.Logf("error marshaling data: %s", err)
+				b.FailNow()
+			}
+			marshalResult = jsonEventData
+		}
+	})
+}
+
+func TestJSONMarshal(t *testing.T) {
+	testMapInput := mapstr.M{
+		"StrTest":       "test",
+		"StrTestEscape": `"test_with_quotes"`,
+		"Uint1":         32,
+		"Uint2":         556,
+		"Float1":        23.0,
+		"Float2":        25.343564,
+		"TestNil":       nil,
+		"TestBool":      false,
+		"TestList":      []interface{}{"strval", 5, false},
+		"TestMap":       map[string]string{"testkey": "val"},
+		"TestMapStr": mapstr.M{"key1": 5, "key2": "strval", "keymap": mapstr.M{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
+		}},
+	}
+
+	testMessage, err := NewValue(testMapInput)
+	require.NoError(t, err)
+
+	jsonEventData, err := json.Marshal(testMessage)
+	require.NoError(t, err)
+	t.Logf("got     : %s", string(jsonEventData))
+
+	stdJSON, err := json.Marshal(testMapInput)
+	require.NoError(t, err)
+	t.Logf("expected: %s", string(stdJSON))
+
+	// JSON string outputs aren't guarenteed to be determinative, so unmarshal back to map so we can compare
+	unmarshaledEvent := mapstr.M{}
+	err = json.Unmarshal(jsonEventData, &unmarshaledEvent)
+	require.NoError(t, err)
+	t.Logf("got     : %s", unmarshaledEvent.StringToPrint())
+
+	unmarshaledJSON := mapstr.M{}
+	err = json.Unmarshal(stdJSON, &unmarshaledJSON)
+	require.NoError(t, err)
+	t.Logf("expected: %s", unmarshaledJSON.StringToPrint())
+
+	require.Equal(t, unmarshaledJSON, unmarshaledEvent)
+
+}
 
 var result *messages.Value
 

--- a/pkg/helpers/struct_test.go
+++ b/pkg/helpers/struct_test.go
@@ -84,11 +84,9 @@ func TestJSONMarshal(t *testing.T) {
 
 	jsonEventData, err := json.Marshal(testMessage)
 	require.NoError(t, err)
-	t.Logf("got     : %s", string(jsonEventData))
 
 	stdJSON, err := json.Marshal(testMapInput)
 	require.NoError(t, err)
-	t.Logf("expected: %s", string(stdJSON))
 
 	// JSON string outputs aren't guarenteed to be determinative, so unmarshal back to map so we can compare
 	unmarshaledEvent := mapstr.M{}

--- a/pkg/helpers/struct_test.go
+++ b/pkg/helpers/struct_test.go
@@ -104,7 +104,7 @@ func TestJSONMarshal(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("EXPECTED: %s", string(stdJSON))
 
-	// JSON string outputs aren't guarenteed to be determinative, so unmarshal back to map so we can compare, test for JSON errors
+	// JSON string outputs aren't guaranteed to be deterministic, so unmarshal back to map so we can compare, test for JSON errors
 	unmarshaledEvent := mapstr.M{}
 	err = json.Unmarshal(jsonWriter.Bytes(), &unmarshaledEvent)
 	require.NoError(t, err)

--- a/pkg/proto/messages/json.go
+++ b/pkg/proto/messages/json.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package messages
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalJSON implements the JSON interface for the value type
+func (val *Value) MarshalJSON() ([]byte, error) {
+	switch typ := val.GetKind().(type) {
+	case *Value_NullValue:
+		return []byte("null"), nil
+	case *Value_NumberValue:
+		return json.Marshal(typ.NumberValue)
+	case *Value_StringValue:
+		return json.Marshal(typ.StringValue)
+	case *Value_BoolValue:
+		if typ.BoolValue {
+			return []byte("true"), nil
+		}
+		return []byte("false"), nil
+	case *Value_StructValue:
+		data, err := typ.StructValue.MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling within value: %w", err)
+		}
+		return data, nil
+	case *Value_ListValue:
+		data, err := typ.ListValue.MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling within value: %w", err)
+		}
+		return data, nil
+	case *Value_TimestampValue:
+		data, err := typ.TimestampValue.AsTime().MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling timestamp within value: %w", err)
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("Unknown type %T in event", typ)
+	}
+}
+
+// MarshalJSON implements the JSON interface for the struct type
+func (sv *Struct) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(sv.GetData())
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling struct type: %w", err)
+	}
+	return data, nil
+}
+
+// MarshalJSON implements the JSON interface for the list Value type
+func (lv *ListValue) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(lv.GetValues())
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling list type: %w", err)
+	}
+	return data, nil
+
+}


### PR DESCRIPTION
Should fix https://github.com/elastic/elastic-agent-shipper/issues/240

This adds a custom `MarshalJSON()` method to the various `*value` types used by the gRPC API, so we can properly marshal the event in a way elasticsearch will expect, and that should be equivalent to how how beats wound send events normally without the shipper in between. 

I included a benchmark test in here as well, as right now it doesn't compare too favorably to marshalling from a hashmap:

```
cpu: Intel(R) Xeon(R) CPU E5-2630 0 @ 2.30GHz
BenchmarkCustomMarshal/marshal_custom_protobuf_message.Value_type-12               37108             43470 ns/op            2907 B/op         67 allocs/op
BenchmarkCustomMarshal/marshal_custom_protobuf_message.Value_type-12               44996             27932 ns/op            2907 B/op         67 allocs/op
BenchmarkCustomMarshal/marshal_custom_protobuf_message.Value_type-12               45432             39136 ns/op            2907 B/op         67 allocs/op
BenchmarkCustomMarshal/marshal_custom_protobuf_message.Value_type-12               33184             42999 ns/op            2907 B/op         67 allocs/op
BenchmarkCustomMarshal/marshal_custom_protobuf_message.Value_type-12               25257             42256 ns/op            2907 B/op         67 allocs/op
BenchmarkCustomMarshal/standard_struct_using_stdlib-12                             62853             22282 ns/op            2353 B/op         49 allocs/op
BenchmarkCustomMarshal/standard_struct_using_stdlib-12                             70322             19309 ns/op            2353 B/op         49 allocs/op
BenchmarkCustomMarshal/standard_struct_using_stdlib-12                             60699             17741 ns/op            2353 B/op         49 allocs/op
BenchmarkCustomMarshal/standard_struct_using_stdlib-12                             87601             14225 ns/op            2353 B/op         49 allocs/op
BenchmarkCustomMarshal/standard_struct_using_stdlib-12                             91309             15955 ns/op            2353 B/op         49 allocs/op
PASS
```

I've taken  a few cracks at optimizing it, but the stdlib json `Marshal()` is so optimized that I haven't been able to make much progress.