### PR TITLE
Fix timestamp fastjson marshal

### DIFF
--- a/pkg/helpers/struct_test.go
+++ b/pkg/helpers/struct_test.go
@@ -63,7 +63,9 @@ func BenchmarkCustomMarshal(b *testing.B) {
 }
 
 func TestJSONMarshal(t *testing.T) {
+	ts := time.Now().UTC() // the timestamppb used by protobuf will remove the location, so set UTC to make DeepEqual happy
 	testMapInput := mapstr.M{
+		"@timestamp":    ts,
 		"StrTest":       "test",
 		"StrTestEscape": `"test_with_quotes"`,
 		"Uint1":         uint32(32),
@@ -239,14 +241,14 @@ func TestStructValue(t *testing.T) {
 			name: "test map conversion",
 			in: mapstr.M{
 				"field1": map[string]interface{}{
-					"value":     false,
-					"value-str": "test",
+					"value":      false,
+					"@timestamp": ts,
 				},
 			},
 			exp: NewStructValue(&messages.Struct{Data: map[string]*messages.Value{
 				"field1": NewStructValue(&messages.Struct{Data: map[string]*messages.Value{
-					"value":     NewBoolValue(false),
-					"value-str": NewStringValue("test"),
+					"value":      NewBoolValue(false),
+					"@timestamp": NewTimestampValue(ts),
 				}}),
 			}}),
 		},

--- a/pkg/proto/messages/json.go
+++ b/pkg/proto/messages/json.go
@@ -39,7 +39,9 @@ func (val *Value) MarshalFastJSON(w *fastjson.Writer) error {
 		}
 		return nil
 	case *Value_TimestampValue:
-		w.Time(typ.TimestampValue.AsTime(), time.RFC3339)
+		w.RawByte('"')
+		w.Time(typ.TimestampValue.AsTime(), time.RFC3339Nano)
+		w.RawByte('"')
 	default:
 		return fmt.Errorf("Unknown type %T in event", typ)
 	}


### PR DESCRIPTION
Fixes an issue where the custom fastjson marshaller wasn't properly quoting strings. Also adds more tests for timestamps, and changes the timestamp format to `FC3339Nano`, which is what the standardlib json marshal does.