### PR TITLE
Add benchmark:{run, diff} mage targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/elastic/elastic-agent-libs v0.2.7
 	github.com/magefile/mage v1.13.0
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/fastjson v1.1.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
@@ -18,7 +19,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.elastic.co/ecszap v1.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/elastic/elastic-agent-libs v0.2.7
 	github.com/magefile/mage v1.13.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/fastjson v1.1.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
@@ -19,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.elastic.co/ecszap v1.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/magefile.go
+++ b/magefile.go
@@ -207,7 +207,8 @@ func InstallBenchStat() error {
 	return nil
 }
 
-func (Benchmark) Run(ctx context.Context, outputFile string) error {
+func (Benchmark) Run(ctx context.Context) error {
+	outputFile := os.Getenv("OUTPUT")
 	mg.Deps(InstallBenchStat)
 	fmt.Println(">> go benchmark:", "Testing")
 	args := []string{
@@ -255,12 +256,12 @@ func (Benchmark) Run(ctx context.Context, outputFile string) error {
 	return nil
 }
 
-func (Benchmark) Diff(ctx context.Context, baseFile string, newFile string, outputFile string) error {
+func (Benchmark) Diff(ctx context.Context) error {
 	mg.Deps(InstallBenchStat)
+	outputFile := os.Getenv("OUTPUT")
+	baseFile := os.Getenv("BASE")
+	nextFile := os.Getenv("NEXT")
 	var args = []string{}
-	if outputFile == "" {
-		outputFile = "benchmark_stats"
-	}
 	if baseFile == "" {
 		log.Printf("Missing baseline benchmark output, benchstat will show a summary for the bechmark")
 	} else {

--- a/magefile.go
+++ b/magefile.go
@@ -199,6 +199,7 @@ func licenser(mode licenserMode) error {
 
 type Benchmark mg.Namespace
 
+// InstallBenchStat installs required plugins for reading benchmarks results
 func InstallBenchStat() error {
 	err := gotool.Install(gotool.Install.Package(goBenchstats))
 	if err != nil {
@@ -207,6 +208,7 @@ func InstallBenchStat() error {
 	return nil
 }
 
+// Run execute the go benchmarks
 func (Benchmark) Run(ctx context.Context) error {
 	outputFile := os.Getenv("OUTPUT")
 	mg.Deps(InstallBenchStat)
@@ -256,6 +258,7 @@ func (Benchmark) Run(ctx context.Context) error {
 	return nil
 }
 
+// Diff compare 2 benchmark outputs
 func (Benchmark) Diff(ctx context.Context) error {
 	mg.Deps(InstallBenchStat)
 	outputFile := os.Getenv("OUTPUT")
@@ -268,7 +271,7 @@ func (Benchmark) Diff(ctx context.Context) error {
 		args = append(args, baseFile)
 	}
 	if nextFile == "" {
-		return fmt.Errorf("Missing candidate benchmark output file, please run first OUTPUT=foo benchmark:run")
+		return fmt.Errorf("Missing candidate benchmark output file, please run first OUTPUT=benchmark_output benchmark:run")
 	} else {
 		args = append(args, nextFile)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,7 +24,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/dev-tools/mage/gotool"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -226,7 +226,7 @@ func (Benchmark) Run(ctx context.Context, outputFile string) error {
 	if outputFile != "" {
 		fileOutput, err := os.Create(createDir(outputFile))
 		if err != nil {
-			return errors.Wrap(err, "failed to create go test output file")
+			fmt.Errorf("failed to create go test output file: %w", err)
 		}
 		defer fileOutput.Close()
 		outputs = append(outputs, fileOutput)
@@ -242,7 +242,7 @@ func (Benchmark) Run(ctx context.Context, outputFile string) error {
 		// Command ran.
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
-			return errors.Wrap(err, "failed to execute go")
+			return fmt.Errorf("failed to execute go: %w", err)
 		}
 
 		// Command ran but failed. Process the output.
@@ -282,7 +282,7 @@ func (Benchmark) Diff(ctx context.Context, baseFile string, newFile string, outp
 	if outputFile != "" {
 		fileOutput, err := os.Create(createDir(outputFile))
 		if err != nil {
-			return errors.Wrap(err, "failed to create go test output file")
+			fmt.Errorf("failed to create benchstat output file: %w", err)
 		}
 		defer fileOutput.Close()
 		outputs = append(outputs, fileOutput)
@@ -298,7 +298,7 @@ func (Benchmark) Diff(ctx context.Context, baseFile string, newFile string, outp
 		// Command ran.
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
-			return errors.Wrap(err, "failed to execute go")
+			return fmt.Errorf("failed to execute go: %w", err)
 		}
 
 		// Command ran but failed. Process the output.
@@ -307,7 +307,7 @@ func (Benchmark) Diff(ctx context.Context, baseFile string, newFile string, outp
 
 	if goTestErr != nil {
 		// No packages were tested. Probably the code didn't compile.
-		return errors.Wrap(goTestErr, "go test returned a non-zero value")
+		return fmt.Errorf("go test returned a non-zero value: %w", goTestErr)
 	}
 
 	return nil
@@ -335,7 +335,8 @@ func createDir(file string) string {
 	// Create the output directory.
 	if dir := filepath.Dir(file); dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			panic(errors.Wrapf(err, "failed to create parent dir for %v", file))
+			fmt.Errorf("Failed to create parent dir for %w", file)
+			panic(err)
 		}
 	}
 	return file


### PR DESCRIPTION
This PR adds 2 new mage targets for the project that execute the go bench benchmarks and benchstat for comparing the results.

Example use of the above is:
```
$ mage benchmark:run benchmark-before
# ..... make changes ......
$ mage benchmark:run benchmark-after
$ mage benchmark:diff benchmark-before benchmark-after
```

Once we are happy with the workflow we can move this part into the `elastic-agent-libs/dev-tools/mage` and reference from there.

The intention of these new mage targets is to be used when adding code to this repo with the above workflow and to integrate them into a GH action and have it report the numbers back to the PR, an example workflow that I was playing around with can be found in https://github.com/alexsapran/elastic-agent-shipper-client/pull/1#issuecomment-1450737792