### PR TITLE
Remove the use of fmt.Sprintf

### DIFF
--- a/pkg/proto/messages/json.go
+++ b/pkg/proto/messages/json.go
@@ -76,7 +76,9 @@ func (sv *Struct) MarshalFastJSON(w *fastjson.Writer) error {
 			beginning = false
 		}
 
-		w.RawString(fmt.Sprintf("\"%s\":", key))
+		w.RawString("\"")
+		w.RawString(key)
+		w.RawString("\":")
 		err := val.MarshalFastJSON(w)
 		if err != nil {
 			return fmt.Errorf("error marshaling value in map: %w", err)


### PR DESCRIPTION
This commit removes the use of fmt.Sprintf because it results in leaking memory to the heap.
It is replaced to writes directly to the writer object.

This has an impact on the speed of the marshaling of objects.

Comparing the gobenchmark before and after

```
goos: darwin
goarch: amd64
pkg: github.com/elastic/elastic-agent-shipper-client/pkg/helpers
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
                                              │   base.txt   │           no_string.txt            │
                                              │    sec/op    │   sec/op     vs base               │
CustomMarshal/marshal_value_using_fastjson-16   5.715µ ±  5%   3.713µ ± 8%  -35.03% (p=0.000 n=8)
CustomMarshal/marshal_value_using_stdlib-16     10.95µ ± 14%   11.26µ ± 7%        ~ (p=0.645 n=8)
geomean                                         7.912µ         6.465µ       -18.30%

                                              │   base.txt   │            no_string.txt            │
                                              │     B/op     │     B/op      vs base               │
CustomMarshal/marshal_value_using_fastjson-16   1.490Ki ± 0%   1.023Ki ± 0%  -31.32% (p=0.000 n=8)
CustomMarshal/marshal_value_using_stdlib-16     2.632Ki ± 0%   2.633Ki ± 0%        ~ (p=0.051 n=8)
geomean                                         1.981Ki        1.641Ki       -17.12%

                                              │  base.txt   │            no_string.txt            │
                                              │  allocs/op  │ allocs/op   vs base                 │
CustomMarshal/marshal_value_using_fastjson-16   42.000 ± 0%   8.000 ± 0%  -80.95% (p=0.000 n=8)
CustomMarshal/marshal_value_using_stdlib-16      32.00 ± 0%   32.00 ± 0%        ~ (p=1.000 n=8) ¹
geomean                                          36.66        16.00       -56.36%
¹ all samples are equal
```

The `marshal_value_using_fastjson` tests the `base` be the code before this change and `no_string` is this change.
We can see that we get 35% faster execution and 80% fewer memory allocations.

 Signed-off-by: Alexandros, Sapranidis <alexandros@elastic.co>